### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,7 @@
     "email": "matheus.brasil10@gmail.com",
     "url": "https://github.com/mabrasil/flat-palettes"
   },
-  "license": {
-    "type": "MIT",
-    "url": ""
-  },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/mabrasil/flat-palettes/issues"
   },


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
